### PR TITLE
Use the updated ansible-runner images on quay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM quay.io/openshift/origin-cli:4.7 as cli
 
-FROM docker.io/ansible/ansible-runner:latest
+FROM quay.io/ansible/ansible-runner:stable-2.9-latest
 COPY --from=cli /usr/bin/oc /usr/bin/oc
-RUN yum -y update && yum -y install python3-kubernetes python3-openshift && yum clean all
+RUN yum -y install yum-utils \
+  && yum-config-manager --enable epel \
+  && yum -y update \
+  && yum -y install python3-kubernetes python3-openshift \
+  && yum clean all


### PR DESCRIPTION
The ansible-runner image on docker hasn't been updated in a very long time. Ansible 2.9.9 has a bug that was discovered trying to run a hook using the nmcli module. https://github.com/ansible-collections/community.general/issues/669

By using the quay image we get 2.9.27, which resolves this and gets us more current. We should also consider moving to 2.11 eventually, but moving to 2.10+ might be a bit disruptive we should probably do some testing before doing so. 2.10 intoduced some pretty big changes, though it shouldn't be anything we can't work through.