### PR TITLE
Use pip to install dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,4 @@ FROM quay.io/openshift/origin-cli:4.7 as cli
 
 FROM quay.io/ansible/ansible-runner:stable-2.9-latest
 COPY --from=cli /usr/bin/oc /usr/bin/oc
-RUN yum -y install yum-utils \
-  && yum-config-manager --enable epel \
-  && yum -y update \
-  && yum -y install python3-kubernetes python3-openshift \
-  && yum clean all
+RUN pip3 install kubernetes openshift


### PR DESCRIPTION
Upstream ansible(-runner) has always used pip for installs on it's images.

We've kind of ignored this and used packages to add kubernetes and openshift, which hasn't been a problem because everything used the platform python version 3.6.

However, they have moved all their images over to use the python 3.8 module, so this is no longer true.

We need to install the extra libraries using pip or build a pile of dependencies for python 3.8 so they will work with the python 3.8 module rpm.

I do not know if or when this might become a problem downstream. It will depend on whether they continue to use and package everything for the platforms default python or start using modules or other methods to use a newer version of python. As of today the runner image is on RHEL 7 using python 2.7 so upstream and down do not closely resemble each other.