### PR TITLE
Upgrade urllib3, pyasn1, aiohttp to address Python CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-cli:4.20 as cli
 
 FROM quay.io/ansible/ansible-runner:stable-2.12-latest
-RUN pip3 install --upgrade 'urllib3>=2.7.0'
+RUN pip3 install --upgrade 'urllib3>=2.7.0' 'pyasn1>=0.6.3' 'aiohttp>=3.13.3'
 COPY --from=cli /usr/bin/oc /usr/bin/oc
 RUN pip3 install kubernetes openshift
 RUN ansible-galaxy collection install kubernetes.core

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/openshift/origin-cli:4.20 as cli
 
 FROM quay.io/ansible/ansible-runner:stable-2.12-latest
+RUN pip3 install --upgrade 'urllib3>=2.7.0'
 COPY --from=cli /usr/bin/oc /usr/bin/oc
 RUN pip3 install kubernetes openshift
 RUN ansible-galaxy collection install kubernetes.core


### PR DESCRIPTION
## Summary

Upgrades Python packages in the final stage to address 7 CVEs:

**urllib3** (>= 2.7.0):
- CVE-2025-66418, CVE-2025-66471, CVE-2026-21441, CVE-2026-44431

**pyasn1** (>= 0.6.3):
- CVE-2026-23490 (DoS via malformed RELATIVE-OID)
- CVE-2026-30922 (DoS via unbounded recursion)

**aiohttp** (>= 3.13.3):
- CVE-2025-69228 (DoS via memory exhaustion from crafted POST)

## Jira tickets
MIG-1809, MIG-1827, MIG-1835, MIG-1916, MIG-1904, MIG-1881, MIG-1863

## Test plan
- [ ] Verify built image contains urllib3 >= 2.7.0, pyasn1 >= 0.6.3, aiohttp >= 3.13.3